### PR TITLE
TST: drafted test for integer return by calc_m_lambda()

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -55,7 +55,7 @@ def calc_m_lambda(i, j, k=1.0, l_lambda=1, l_phi=1, N=0, MAXD=4):
                                                l_phi,
                                                N)
 
-    return m_lambda
+    return int(m_lambda)
 
 def calc_m_phi(i, j, k=1.0, l_lambda=1, l_phi=1, N=0, MAXD=4):
     '''
@@ -94,7 +94,7 @@ def calc_m_phi(i, j, k=1.0, l_lambda=1, l_phi=1, N=0, MAXD=4):
                                          l_phi,
                                          N)
 
-    return m_phi
+    return int(m_phi)
 
 def _grid_build_coef(k=1.0, l_lambda=1, l_phi=1, N=0):
     # utility function needed by calc_m_lambda and calc_m_phi

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -82,3 +82,23 @@ def test_grid_level_1_edge_count_boundary():
     max_allowed = int(result.size / 2.)
 
     assert np.count_nonzero(result) < max_allowed
+
+@pytest.mark.parametrize("i, j, k, l_lambda, l_phi, N", [
+                         (2, 3, 1.0, 2.5, 2.5, 10),
+                         (4, 9, 1.0, 4.5, 9.5, 200),
+                         (4, 9, 1.0, 4.5, 9.5, 0),
+                         ])
+def test_calc_m_lambda(i, j, k, l_lambda, l_phi, N):
+    # since the manuscript defines m_lambda
+    # as the number of cells in the latitude
+    # direction, we should at least ensure
+    # that the result with reasonable
+    # input is always an integer number
+    # of cells
+    result = lib.calc_m_lambda(i=i,
+                               j=j,
+                               l_lambda=l_lambda,
+                               l_phi=l_phi,
+                               N=N)
+    print("result:", result)
+    assert isinstance(result, int)

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -88,17 +88,27 @@ def test_grid_level_1_edge_count_boundary():
                          (4, 9, 1.0, 4.5, 9.5, 200),
                          (4, 9, 1.0, 4.5, 9.5, 0),
                          ])
-def test_calc_m_lambda(i, j, k, l_lambda, l_phi, N):
-    # since the manuscript defines m_lambda
-    # as the number of cells in the latitude
-    # direction, we should at least ensure
-    # that the result with reasonable
-    # input is always an integer number
-    # of cells
-    result = lib.calc_m_lambda(i=i,
-                               j=j,
-                               l_lambda=l_lambda,
-                               l_phi=l_phi,
-                               N=N)
-    print("result:", result)
-    assert isinstance(result, int)
+class TestGridSubdivisions(object):
+
+    def test_calc_m_lambda(self, i, j, k, l_lambda, l_phi, N):
+        # since the manuscript defines m_lambda
+        # as the number of cells in the latitude
+        # direction, we should at least ensure
+        # that the result with reasonable
+        # input is always an integer number
+        # of cells
+        result = lib.calc_m_lambda(i=i,
+                                   j=j,
+                                   l_lambda=l_lambda,
+                                   l_phi=l_phi,
+                                   N=N)
+        assert isinstance(result, int)
+
+    # similarly for m_phi
+    def test_calc_m_phi(self, i, j, k, l_lambda, l_phi, N):
+        result = lib.calc_m_phi(i=i,
+                                j=j,
+                                l_lambda=l_lambda,
+                                l_phi=l_phi,
+                                N=N)
+        assert isinstance(result, int)


### PR DESCRIPTION
This PR drafts a simple unit test to ensure an `int` type result returned by `calc_m_lambda()`, but currently this is not the case.

This surprises me because the manuscript describes `m_lambda` as a "number of cells," which I suspect would always have to be an integer.

Need to investigate.