### PR TITLE
TST: expanding / update CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   # not actually using the Travis versions of Python shown here, but useful to organize matrix
   # see: https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html#the-travis-yml-file
   - "3.6"
+  - "3.7"
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -11,9 +12,9 @@ before_install:
   - conda config --set always_yes yes
   - conda update conda
 install:
-  - conda create -q -n pyenv libgfortran python=$TRAVIS_PYTHON_VERSION numpy=1.16 scipy=1.2.1 pytest pytest-cov pyyaml
-  - source activate pyenv
   - conda config --add channels conda-forge
+  - conda create -q -n pyenv libgfortran python=$TRAVIS_PYTHON_VERSION numpy=1.17 scipy=1.3.0 pytest pytest-cov pyyaml
+  - source activate pyenv
   - conda install codecov
   - chmod +x ./
 script:


### PR DESCRIPTION
* add Python 3.7 to Travis matrix

* update Travis CI testing to use latest
stable releases of NumPy (1.17) and SciPy
(1.3.0)