### PR TITLE
ENH: produce level 1 grid centers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
   - conda update conda
 install:
   - conda config --add channels conda-forge
-  - conda create -q -n pyenv libgfortran python=$TRAVIS_PYTHON_VERSION numpy scipy pytest pytest-cov pyyaml pycodestyle
+  - conda create -q -n pyenv python=$TRAVIS_PYTHON_VERSION 
   - source activate pyenv
+  - python -m pip install numpy scipy pytest pytest-cov pyyaml pycodestyle
   - conda install codecov
   - chmod +x ./
 script:

--- a/probe_grid.py
+++ b/probe_grid.py
@@ -14,6 +14,7 @@ import copy
 import scipy
 import scipy.spatial
 from scipy.spatial import geometric_slerp
+from tqdm import tqdm
 
 # the input will be a spherical triangle that
 # covers exactly 1/8 the surface area of the unit
@@ -57,7 +58,19 @@ cartesian_coords_cells_L4) = results
 # along with the spherical polygon, albeit with
 # crude matplotlib 3D handling
 fig_level_1 = plt.figure()
+fig_level_1_centers = plt.figure()
+# maintain a separate figure for the level
+# grid cell "centers"
 ax = fig_level_1.add_subplot(111, projection='3d')
+ax_centers = fig_level_1_centers.add_subplot(111, projection='3d')
+grid_cell_center_coords_L1 = lib.produce_level_1_grid_centers(
+                                 spherical_polyon)[0]
+ax_centers.scatter(grid_cell_center_coords_L1[..., 0],
+                   grid_cell_center_coords_L1[..., 1],
+                   grid_cell_center_coords_L1[..., 2],
+                   marker='.',
+                   color='black')
+
 ax.scatter(cartesian_coords_cells_L1[...,0],
            cartesian_coords_cells_L1[...,1],
            cartesian_coords_cells_L1[...,2],
@@ -152,7 +165,8 @@ has_black_legend_entry = False
 has_yellow_legend_entry = False
 has_red_legend_entry = False
 
-for key, edge_entry in dict_edge_data.items():
+for key, edge_entry in tqdm(dict_edge_data.items(),
+                            desc='iter_count'):
     current_edge = edge_entry['edge']
     current_edge_count = edge_entry['edge_count']
     dist = scipy.spatial.distance.cdist(spherical_polyon,
@@ -187,9 +201,15 @@ for key, edge_entry in dict_edge_data.items():
                 current_edge[..., 2],
                 label=label,
                 color=colors[current_edge_count])
+        # for the L1 centers plot we just want
+        # the grid outline for now
+        ax_centers.plot(current_edge[..., 0],
+                        current_edge[..., 1],
+                        current_edge[..., 2],
+                        color='k',
+                        alpha=0.3)
     plot = True
     iter_count += 1
-    print(iter_count, 'of', total_iter, 'iterations')
 
 polygon = Poly3DCollection([interpolated_polygon], alpha=0.3)
 polygon._facecolors2d=polygon._facecolors3d
@@ -202,6 +222,10 @@ ax.elev = -30
 ax.set_xlabel('x')
 ax.set_ylabel('y')
 ax.set_zlabel('z')
+
+ax_centers.set_xlabel('x')
+ax_centers.set_ylabel('y')
+ax_centers.set_zlabel('z')
 ax.legend(loc="lower left",
           bbox_to_anchor=(0,-0.1),
           ncol=2)
@@ -214,3 +238,7 @@ ax.set_title('Prototype Multilevel Spherical Grid Data '
 
 fig_level_1.savefig("level_1_grid.png", dpi=300)
 fig_level_1.set_size_inches(10,10)
+
+ax_centers.azim = 70
+ax_centers.elev = 50
+fig_level_1_centers.savefig("level_1_centers.png", dpi=300)

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import (assert_almost_equal,
+                           assert_allclose)
 from math import sqrt
 import lib
 
@@ -361,3 +362,42 @@ class TestGridCenterPoint(object):
                                        grid_cell_lat_2=lat_2)
 
         assert_almost_equal(actual, expected)
+
+def test_level_1_grid_centers():
+    # check some simple properties of the level 1
+    # grid center data structure produced by
+    # produce_level_1_grid_centers()
+
+    # since the L1 grid is fixed, the choice
+    # of input spherical_polygon isn't too
+    # important here
+    spherical_polygon = np.array([[0, 1, 0],
+                                  [0, 0, 1],
+                                  [-1, 0, 0]], dtype=np.float64)
+
+    # retrieve the edge counts for level 1
+    # from another function, so that we
+    # have a reference data structure for
+    # shape comparison
+    expected_edge_count_array_L1 = lib.cast_subgrids(spherical_polygon)[0]
+
+    (actual_grid_cell_center_coords_L1,
+     actual_edge_count_array_L1) = lib.produce_level_1_grid_centers(
+                                            spherical_polygon)
+
+    # the edge count array should have been
+    # passed through produce_level_1_grid_centers()
+    # unchanged
+    assert_allclose(actual_edge_count_array_L1,
+                    expected_edge_count_array_L1)
+
+    # the number of grid cell center coordinates
+    # should match the edge count data structure size
+    assert_allclose(actual_grid_cell_center_coords_L1.shape[0],
+                    expected_edge_count_array_L1.size)
+
+    # all L1 grid cell center coords should be on the unit
+    # sphere/norm
+    norms = np.linalg.norm(actual_grid_cell_center_coords_L1, axis=1)
+    expected_norms = np.ones((expected_edge_count_array_L1.size,))
+    assert_allclose(norms, expected_norms)


### PR DESCRIPTION
Fixes #38 

* abstract some longitude transition point
code to convert_cartesian_to_lat_long() to
avoid duplication for handling values near 180

* draft produce_level_1_grid_centers(), a function
designed to generate a data structure with the centers
of the level 1 grid cells; also, add some initial/crude
unit testing for this function

* add some plotting code for "visual debugging" of
produce_level_1_grid_centers()

This isn't working right just yet---see plot below for misplaced grid center points at level 1:

![level_1_centers](https://user-images.githubusercontent.com/7903078/71609666-8444df80-2b47-11ea-875e-53241f4972d7.png)
